### PR TITLE
Added PUID as build argument

### DIFF
--- a/buster-root/Dockerfile
+++ b/buster-root/Dockerfile
@@ -4,7 +4,7 @@
 FROM debian:buster-slim
 
 LABEL maintainer="walentinlamonos@gmail.com"
-ARG PUID=27444
+ARG PUID=1000
 
 ENV STEAMCMDDIR /home/steam/steamcmd
 

--- a/buster-root/Dockerfile
+++ b/buster-root/Dockerfile
@@ -4,6 +4,7 @@
 FROM debian:buster-slim
 
 LABEL maintainer="walentinlamonos@gmail.com"
+ARG PUID=27444
 
 ENV STEAMCMDDIR /home/steam/steamcmd
 
@@ -21,7 +22,7 @@ RUN set -x \
 		lib32gcc1=1:8.3.0-6 \
 		wget=1.20.1-1.1 \
 		ca-certificates=20190110 \
-	&& useradd -m steam \
+	&& useradd -u $PUID -m steam \
 	&& su steam -c \
 		"mkdir -p ${STEAMCMDDIR} \
 		&& cd ${STEAMCMDDIR} \

--- a/buster/Dockerfile
+++ b/buster/Dockerfile
@@ -4,7 +4,7 @@
 FROM debian:buster-slim
 
 LABEL maintainer="walentinlamonos@gmail.com"
-ARG PUID=27444
+ARG PUID=1000
 
 ENV STEAMCMDDIR /home/steam/steamcmd
 

--- a/buster/Dockerfile
+++ b/buster/Dockerfile
@@ -4,6 +4,7 @@
 FROM debian:buster-slim
 
 LABEL maintainer="walentinlamonos@gmail.com"
+ARG PUID=27444
 
 ENV STEAMCMDDIR /home/steam/steamcmd
 
@@ -21,7 +22,7 @@ RUN set -x \
 		lib32gcc1=1:8.3.0-6 \
 		wget=1.20.1-1.1 \
 		ca-certificates=20190110 \
-	&& useradd -m steam \
+	&& useradd -u $PUID -m steam \
 	&& su steam -c \
 		"mkdir -p ${STEAMCMDDIR} \
 		&& cd ${STEAMCMDDIR} \


### PR DESCRIPTION
This makes it so much easier to mount volumes to a folder on a server and be able to read/write the files outside the container, since the host user and the user in the container must have the same uid