### PR TITLE
added env to fix steamclient.so not found

### DIFF
--- a/buster-root/Dockerfile
+++ b/buster-root/Dockerfile
@@ -9,6 +9,7 @@ ARG PUID=1000
 ENV USER steam
 ENV HOMEDIR "/home/${USER}"
 ENV STEAMCMDDIR "${HOMEDIR}/steamcmd"
+ENV LD_LIBRARY_PATH "${HOMEDIR}/.steam/sdk32:$LD_LIBRARY_PATH"
 
 # Install, update & upgrade packages
 # Create user for the server

--- a/buster/Dockerfile
+++ b/buster/Dockerfile
@@ -9,6 +9,7 @@ ARG PUID=1000
 ENV USER steam
 ENV HOMEDIR "/home/${USER}"
 ENV STEAMCMDDIR "${HOMEDIR}/steamcmd"
+ENV LD_LIBRARY_PATH "${HOMEDIR}/.steam/sdk32:$LD_LIBRARY_PATH"
 
 # Install, update & upgrade packages
 # Create user for the server


### PR DESCRIPTION
Add environment variables to fix the following errors.

```
[S_API FAIL] SteamAPI_Init() failed; SteamAPI_IsSteamRunning() failed.
dlopen failed trying to load:
steamclient.so
with error:
steamclient.so: cannot open shared object file: No such file or directory
[S_API FAIL] SteamAPI_Init() failed; unable to locate a running instance of Steam, or a local steamclient.dll.
FATAL ERROR (shutting down): Unable to initialize Steam.
```