### PR TITLE
Fix Package Versions and Readline Errors

### DIFF
--- a/trixie/Dockerfile
+++ b/trixie/Dockerfile
@@ -13,13 +13,13 @@ ENV STEAMCMDDIR="${HOMEDIR}/steamcmd"
 RUN set -x \
     # Install, update & upgrade packages
     && apt-get update \
-    && apt-get install -y --no-install-recommends --no-install-suggests \
+    && DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends --no-install-suggests \
         lib32stdc++6=14.2.0-19 \
         lib32gcc-s1=14.2.0-19 \
         ca-certificates=20250419 \
         nano=8.4-1 \
         curl=8.14.1-2+deb13u2 \
-        locales=2.41-12+deb13u1 \
+        locales=2.41-12+deb13u2 \
     && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
     && dpkg-reconfigure --frontend=noninteractive locales \
     # Create unprivileged user


### PR DESCRIPTION
### Fixed

- Set the Aptitude front end variable to 'noninteractive' to resolve multiple Perl Readline errors during image build.
- Updated the locales package version from 2.41-12+deb13u1 to 2.41-12+deb13u2.